### PR TITLE
The arguments should not have quotes around them as a whole

### DIFF
--- a/src/testup/editor.rb
+++ b/src/testup/editor.rb
@@ -44,7 +44,7 @@ module TestUp
     arguments = self.arguments
     arguments.gsub!('{FILE}', file)
     arguments.gsub!('{LINE}', line)
-    command = %["#{editor}" "#{arguments}"]
+    command = %["#{editor}" #{arguments}]
     system(command)
   end
 


### PR DESCRIPTION
Some arguments require there being no quotes.  This fix removes the quotes that are added to the arguments supplied by the user.  If the user needs quotes around their arguments, they can add them to their arguments.
