### PR TITLE
Fix issue #90: Turn off console on startup, add a config in menu

### DIFF
--- a/src/testup/core.rb
+++ b/src/testup/core.rb
@@ -39,13 +39,13 @@ module TestUp
   # Sketchup.write_default(TestUp::PLUGIN_ID, 'dev-mode', true)
   DEBUG = Sketchup.read_default(PLUGIN_ID, 'dev-mode', false)
 
-  # <debug>
-  if defined?(SKETCHUP_CONSOLE)
-    SKETCHUP_CONSOLE.show
-  elsif defined?(LAYOUT_CONSOLE)
-    LAYOUT_CONSOLE.show
+  if Sketchup.read_default(PLUGIN_ID, 'open_console_on_startup', false)
+    if defined?(SKETCHUP_CONSOLE)
+      SKETCHUP_CONSOLE.show
+    elsif defined?(LAYOUT_CONSOLE)
+      LAYOUT_CONSOLE.show
+    end
   end
-  # </debug>
 
   PATH_IMAGES     = File.join(PATH, 'images').freeze
   PATH_JS_SCRIPTS = File.join(PATH, 'js').freeze
@@ -130,6 +130,7 @@ module TestUp
     @settings[:run_in_gui] = nil
     @settings[:verbose_console_tests] = nil
     @settings[:paths_to_testsuites] = nil
+    @settings[:open_console_on_startup] = nil
   end
 
 

--- a/src/testup/ui.rb
+++ b/src/testup/ui.rb
@@ -84,6 +84,16 @@ module TestUp
     cmd.status_bar_text = 'Open folder with logs.'
     cmd_open_logs = cmd
 
+    cmd = UI::Command.new('Open console on startup') {
+      self.settings[:open_console_on_startup] = !self.settings[:open_console_on_startup]
+    }
+    cmd.tooltip = 'Open console on startup'
+    cmd.status_bar_text = 'Open console on startup.'
+    cmd.set_validation_proc {
+      self.settings[:open_console_on_startup] ? MF_CHECKED : MF_ENABLED
+    } if defined?(Sketchup)
+    cmd_open_console_on_startup = cmd
+
     cmd = UI::Command.new('Reload TestUp') {
       TESTUP_CONSOLE.clear
       window_visible = @window && @window.visible?
@@ -136,6 +146,7 @@ module TestUp
       sub_menu.add_item('Remove Run...') { self::Runs.remove }
       menu.add_separator
       menu.add_item(cmd_open_logs)
+      menu.add_item(cmd_open_console_on_startup)
       menu.add_item(cmd_toggle_run_tests_in_console)
       menu.add_item(cmd_toggle_verbose_console_tests)
       menu.add_item(cmd_display_minitest_help)


### PR DESCRIPTION
Debug helpers may better fit into a personal customization branch since it may go into the way of end users' workflows. As discussed in https://github.com/Aerilius/testup-2/commit/8d7a6b1d48d0d345d3eb4308ce78916cb8166d64#r10604974,  instead of removing it I turned it into an optional feature.