### PR TITLE
Fix Application & Arguments can't be save from Preferences

### DIFF
--- a/dialogs/preferences.ts
+++ b/dialogs/preferences.ts
@@ -98,6 +98,13 @@ window.app = new Vue({
     addPath() {
       sketchup.addPath();
     },
+    changeEditorExecutable: function(ev) {
+      this.config.editor.executable = ev.target.value;
+      this.config.editor.application = ev.target.value;
+    },
+    changeEditorArguments: function(ev) {
+      this.config.editor.arguments = ev.target.value;
+    },
     cancel() {
       sketchup.cancel();
     },

--- a/dialogs/preferences.ts
+++ b/dialogs/preferences.ts
@@ -100,7 +100,6 @@ window.app = new Vue({
     },
     changeEditorExecutable: function(ev) {
       this.config.editor.executable = ev.target.value;
-      this.config.editor.application = ev.target.value;
     },
     changeEditorArguments: function(ev) {
       this.config.editor.arguments = ev.target.value;

--- a/src/testup/ui/html/preferences.html
+++ b/src/testup/ui/html/preferences.html
@@ -58,11 +58,11 @@
       <su-group title="Code Editor" id="tuCodeEditor">
 
         <div class="tu-input-group">
-          <su-input label="Application:" v-model="config.editor.executable"></su-input>
+          <su-input label="Application:" v-on:keyup.native="changeEditorExecutable" v-model="config.editor.executable"></su-input>
         </div>
 
         <div class="tu-input-group">
-          <su-input label="Arguments:" v-model="config.editor.arguments"></su-input>
+          <su-input label="Arguments:" v-on:keyup.native="changeEditorArguments" v-model="config.editor.arguments"></su-input>
           <su-label>Variables: {FILE} {LINE}</su-label>
         </div>
 

--- a/src/testup/ui/preferences.rb
+++ b/src/testup/ui/preferences.rb
@@ -94,7 +94,7 @@ module TestUp
       Log.info "event_save_config(...)"
       Log.debug config.inspect
       # Save editor config:
-      application = config['editor']['application']
+      application = config['editor']['executable']
       arguments = config['editor']['arguments']
       Editor.change(application, arguments)
       paths = config['test_suite_paths']


### PR DESCRIPTION
[fix the issue 165](https://github.com/SketchUp/testup-2/issues/165)

![image](https://user-images.githubusercontent.com/38310238/58743437-a2d4e200-8463-11e9-930f-16bdd2bde697.png)
