### PR TITLE
Fix broken editor preference. Fixes #165

### DIFF
--- a/dialogs/components/su-input.vue
+++ b/dialogs/components/su-input.vue
@@ -1,7 +1,9 @@
 <template>
   <label class="su-input" v-bind:class="{ hasLabel: label }">
     <span v-if="label">{{ label }}</span>
-    <input v-bind:value="value" />
+    <input
+      v-bind:value="value"
+      v-on:input="$emit('input', $event.target.value)" />
   </label>
 </template>
 

--- a/src/testup/editor.rb
+++ b/src/testup/editor.rb
@@ -75,6 +75,7 @@ module TestUp
     arguments.gsub!('{FILE}', file)
     arguments.gsub!('{LINE}', line)
     command = %["#{editor}" #{arguments}]
+    puts command
     system(command)
   end
 

--- a/src/testup/ui/preferences.rb
+++ b/src/testup/ui/preferences.rb
@@ -94,7 +94,7 @@ module TestUp
       Log.info "event_save_config(...)"
       Log.debug config.inspect
       # Save editor config:
-      application = config['editor']['application']
+      application = config['editor']['executable']
       arguments = config['editor']['arguments']
       Editor.change(application, arguments)
       paths = config['test_suite_paths']


### PR DESCRIPTION
Two issues:

- It was using the wrong key from the config data from the HtmlDialog
- The custom Vue input component wasn't emitting an event that `v-model` could use to properly bind the values.