### PR TITLE
Replace MiniTest with Minitest

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,9 +177,9 @@ Output: "%CONFIG_DIR%/tests/ui-tests-results.json"
 
 ## Troubleshooting
 
-### MiniTest
+### Minitest
 
-If you should get errors that relate to failing to install MiniTest then you
+If you should get errors that relate to failing to install Minitest then you
 can attempt to install manually from a backup copy in this GitHub repository:
 
 ```ruby

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "testup",
   "version": "2.4.1",
-  "description": "MiniTest runner for SketchUp",
+  "description": "Minitest runner for SketchUp",
   "author": "Trimble Inc.",
   "license": "MIT",
   "private": true,

--- a/src/testup/console.rb
+++ b/src/testup/console.rb
@@ -67,7 +67,7 @@ module TestUp
 
     def sync=(value)
       # The SketchUp console always output immediately so setting to false is of
-      # no use. Currently raising an exception in case the MiniTest framework
+      # no use. Currently raising an exception in case the Minitest framework
       # should depend on setting sync to false.
       # However, it looks like it only tries to set it to true.
       unless value

--- a/src/testup/debug.rb
+++ b/src/testup/debug.rb
@@ -29,7 +29,7 @@ module TestUp
   # plugins has been loaded.
   def self.display_minitest_help
     TESTUP_CONSOLE.show
-    MiniTest.run(['--help'])
+    Minitest.run(['--help'])
   rescue SystemExit
   end
 

--- a/src/testup/debug_reporter.rb
+++ b/src/testup/debug_reporter.rb
@@ -13,7 +13,7 @@ require 'testup/minitest_setup.rb'
 require 'testup/app_files.rb'
 
 
-# Patching MiniTest because we currently use 5.4.3 which doesn't have `prerecord`.
+# Patching Minitest because we currently use 5.4.3 which doesn't have `prerecord`.
 module Minitest
   class Runnable
 
@@ -63,7 +63,7 @@ end
 
 module TestUp
 # Based on Minitest::SummaryReporter
-class DebugReporter < MiniTest::StatisticsReporter
+class DebugReporter < Minitest::StatisticsReporter
 
   def initialize(options)
     io_null = StringIO.new

--- a/src/testup/file_reporter.rb
+++ b/src/testup/file_reporter.rb
@@ -14,7 +14,7 @@ require 'testup/app_files.rb'
 
 module TestUp
 # Based on Minitest::SummaryReporter
-class FileReporter < MiniTest::StatisticsReporter
+class FileReporter < Minitest::StatisticsReporter
 
   include AppFiles
 
@@ -22,7 +22,7 @@ class FileReporter < MiniTest::StatisticsReporter
   attr_accessor :old_sync
 
   # Hack: Find a better way to pass test suite title and path to the reporter.
-  #       Maybe add custom options to the TestUp MiniTest plugin - and forward
+  #       Maybe add custom options to the TestUp Minitest plugin - and forward
   #       info via that?
   @@title = 'Untitled'
   @@path = nil

--- a/src/testup/minitest_plugins/minitest/testup_plugin.rb
+++ b/src/testup/minitest_plugins/minitest/testup_plugin.rb
@@ -14,7 +14,7 @@ require 'testup/reporter'
 
 module Minitest
 
-  TestUp::Log.trace :minitest, 'MiniTest TestUp Extension discovered...'
+  TestUp::Log.trace :minitest, 'Minitest TestUp Extension discovered...'
 
   def self.plugin_testup_options opts, options # :nodoc:
     opts.on '-t', '--testup', 'Run tests in TestUp GUI.' do
@@ -31,16 +31,16 @@ module Minitest
   end
 
   def self.plugin_testup_init(options)
-    TestUp::Log.trace :minitest, 'MiniTest TestUp Extension loading...'
+    TestUp::Log.trace :minitest, 'Minitest TestUp Extension loading...'
     if TestUp.settings[:run_in_gui]
-      TestUp::Log.trace :minitest, 'MiniTest TestUp Extension in GUI mode'
+      TestUp::Log.trace :minitest, 'Minitest TestUp Extension in GUI mode'
       # Disable the default reporters as otherwise they'll print lots of data to
       # the console while the test runs. No need for that.
       self.reporter.reporters.clear
       # Add the reporters needed for TestUp.
       self.reporter << TestUp::Reporter.new($stdout, options)
     else
-      TestUp::Log.trace :minitest, 'MiniTest TestUp Extension in console mode'
+      TestUp::Log.trace :minitest, 'Minitest TestUp Extension in console mode'
     end
     # Always log to file.
     # TODO(thomthom): Will this add multiple FileReporters?

--- a/src/testup/minitest_setup.rb
+++ b/src/testup/minitest_setup.rb
@@ -14,8 +14,8 @@ $stdout = TestUp::TESTUP_CONSOLE
 $stderr = TestUp::TESTUP_CONSOLE
 
 
-# Load MiniTest. This is a modification from minitest/autoload.rb which doesn't
-# run the tests when SketchUp exits because MiniTest.autoload uses at_exit {}.
+# Load Minitest. This is a modification from minitest/autoload.rb which doesn't
+# run the tests when SketchUp exits because Minitest.autoload uses at_exit {}.
 
 require "rubygems"
 gem "minitest"
@@ -99,11 +99,11 @@ Minitest.parallel_executor = Minitest::Parallel::Executor.new(0)
 # Configure Ruby such that the TestUp reporter can be found without creating
 # gem for it.
 #
-# MiniTest uses Gem.find_files to look for extensions by globbing
+# Minitest uses Gem.find_files to look for extensions by globbing
 # { }"minitest/*_plugin.rb". To avoid making a gem that needs installing, make
 # use of the fact that by default Gem.find_files will search in $LOAD_PATH.
 #
-# Verify by checking after `MiniTest.run`:
+# Verify by checking after `Minitest.run`:
 # Minitest.extensions
 # > ["pride", "testup"]
 $LOAD_PATH << File.join(__dir__, 'minitest_plugins')

--- a/src/testup/reporter.rb
+++ b/src/testup/reporter.rb
@@ -9,7 +9,7 @@ require 'testup/minitest_setup.rb'
 
 
 module TestUp
-# Doc comment from MiniTest::StatisticsReporter:
+# Doc comment from Minitest::StatisticsReporter:
 #
 #   A reporter that gathers statistics about a test run. Does not do
 #   any IO because meant to be used as a parent class for a reporter
@@ -17,7 +17,7 @@ module TestUp
 #
 #   If you want to create an entirely different type of output (eg,
 #   CI, HTML, etc), this is the place to start.
-class Reporter < MiniTest::StatisticsReporter
+class Reporter < Minitest::StatisticsReporter
 
   @@results = []
 

--- a/src/testup/test_discoverer.rb
+++ b/src/testup/test_discoverer.rb
@@ -42,10 +42,10 @@ module TestUp
       Log.trace :discover, ">>> #{self.class}.discover"
       @errors.clear
 
-      # Reset list of runnables MiniTest knows about.
+      # Reset list of runnables Minitest knows about.
       # Undefine all TestUp::TestCase sub-classes and remove them from
       # Minitest's list of known runnables.
-      MiniTest::Runnable.runnables.reject! { |klass|
+      Minitest::Runnable.runnables.reject! { |klass|
         next unless Sandbox.valid_test_class?(klass)
         path = klass.name.split('::').map(&:to_sym)
         leaf = path.pop
@@ -148,7 +148,7 @@ module TestUp
         klass.ancestors[1..-1].include?(TestUp::TestCase)
       end
       def self.minitest_runnables
-        MiniTest::Runnable.runnables.select { |klass|
+        Minitest::Runnable.runnables.select { |klass|
           self.valid_test_class?(klass)
         }
       end

--- a/src/testup/test_runner.rb
+++ b/src/testup/test_runner.rb
@@ -51,7 +51,7 @@ module TestUp
       begin
         progress.set_state(TaskbarProgress::NORMAL)
         API.suppress_warning_dialogs {
-          MiniTest.run(arguments)
+          Minitest.run(arguments)
         }
       rescue SystemExit
         Log.warn 'Minitest called exit.'
@@ -78,7 +78,7 @@ module TestUp
         arguments << '--seed'
         arguments << options[:seed].to_s
       end
-      # When running TestUp from the UI, make sure to load the MiniTest plugin.
+      # When running TestUp from the UI, make sure to load the Minitest plugin.
       # arguments << '--testup' if options[:run_in_gui]
       arguments << '--testup' if options[:ui] # TODO:
       arguments << '--testup_ci' if options[:ci]
@@ -90,7 +90,7 @@ module TestUp
     # return [Array<String>]
     def parse(tests)
       # If tests end with a `#` it means the whole test case should be run.
-      # Automatically fix the regex so MiniTest pick it up correctly.
+      # Automatically fix the regex so Minitest pick it up correctly.
       tests.map { |pattern|
         pattern << '.+' if pattern =~ /\#$/
         pattern


### PR DESCRIPTION
In Minitest v5.0.0, the namespace changed from `MiniTest` to `Minitest`.

I believe this PR updates all the files that used `MiniTest`.