### PR TITLE
Fix #210 Recreate Ruby's line breaks in Puts

### DIFF
--- a/src/testup/console.rb
+++ b/src/testup/console.rb
@@ -54,11 +54,15 @@ module TestUp
       if args.empty?
         write $/
       else
-        for arg in args
-          line = arg.to_s
-          write(line)
-          if line.empty? || !line.end_with?($/)
-            write($/)
+        for arg in args # Why not 'args.each do |arg|' ?
+          if arg.is_a?(Array)
+            arg.each { |e| puts(e) }
+          else
+            line = arg.to_s
+            write(line)
+            if line.empty? || !line.end_with?($/)
+              write($/)
+            end
           end
         end
       end


### PR DESCRIPTION

I may have a fix for #210.

Without TestUp `puts [1,2,3]` outputs as:
```
1
2
3
```
Without TestUp it outputs as `[1, 2, 3]`.

This fix restores the default Ruby behavior to puts for Arrays.

Not sure if there are other classes affected, or if there is a more generalized way to swap out `to_s` on the line `line = arg.to_s` to make the method always act as native Ruby `puts`.

I'm also not sure if this proposed fix has other consequences for TestUp and Minitest, or if there is a completely different way to address this architecturally in such way that we don't have to override `puts`.